### PR TITLE
[CI] Remove composer cache from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ before_script:
   - if [ "$INTEGRATION_TEST" == "enabled" ]; then chmod +x docker-compose; fi;
   - if [ "$INTEGRATION_TEST" == "enabled" ]; then sudo mv docker-compose /usr/local/bin; fi;
   - composer self-update
-  - composer install --prefer-source
   - if [ "$DEPENDENCIES" == "stable" ]; then composer update --prefer-stable; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest --prefer-stable; fi;
 
 script:
   - if [ "$INTEGRATION_TEST" == "disabled" ]; then make quick-test; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,3 @@ script:
 
 after_script:
   - make clean
-
-cache:
-  directories:
-    - $HOME/.composer/cache


### PR DESCRIPTION
There are weird issues with the travis build when using the composer cache and `ocramius/package-versions` library. Removing the cache for now until further investigation is finished.