### PR TITLE
[FEATURE] Add low level deletion API

### DIFF
--- a/src/Requests/Functions.php
+++ b/src/Requests/Functions.php
@@ -174,3 +174,21 @@ function validateSchemaId($schemaId): string
 
     return (string) $schemaId;
 }
+
+function deleteSubjectRequest(string $subjectName)
+{
+    return new Request(
+        'DELETE',
+        (new UriTemplate())->expand('/subjects/{name}', ['name' => $subjectName]),
+        ['Accept' => 'application/vnd.schemaregistry.v1+json']
+    );
+}
+
+function deleteSubjectVersionRequest(string $subjectName, string $versionId)
+{
+    return new Request(
+        'DELETE',
+        (new UriTemplate())->expand('/subjects/{name}/versions/{version}', ['name' => $subjectName, 'version' => $versionId]),
+        ['Accept' => 'application/vnd.schemaregistry.v1+json']
+    );
+}

--- a/test/Requests/FunctionsTest.php
+++ b/test/Requests/FunctionsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace FlixTech\SchemaRegistryApi\Test\Requests;
 
+use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectRequest;
+use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectVersionRequest;
 use PHPUnit\Framework\TestCase;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_FORWARD;
@@ -285,5 +287,35 @@ class FunctionsTest extends TestCase
     {
         $this->assertSame('3', validateSchemaId(3));
         $this->assertSame('3', validateSchemaId('3'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_produce_a_valid_subject_deletion_request()
+    {
+        $request = deleteSubjectRequest('test');
+
+        $this->assertEquals('DELETE', $request->getMethod());
+        $this->assertEquals('/subjects/test', $request->getUri());
+        $this->assertEquals(['application/vnd.schemaregistry.v1+json'], $request->getHeader('Accept'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_produce_a_valid_subject_version_deletion_request()
+    {
+        $request = deleteSubjectVersionRequest('test', VERSION_LATEST);
+
+        $this->assertEquals('DELETE', $request->getMethod());
+        $this->assertEquals('/subjects/test/versions/latest', $request->getUri());
+        $this->assertEquals(['application/vnd.schemaregistry.v1+json'], $request->getHeader('Accept'));
+
+        $request = deleteSubjectVersionRequest('test', '5');
+
+        $this->assertEquals('DELETE', $request->getMethod());
+        $this->assertEquals('/subjects/test/versions/5', $request->getUri());
+        $this->assertEquals(['application/vnd.schemaregistry.v1+json'], $request->getHeader('Accept'));
     }
 }

--- a/test/Requests/FunctionsTest.php
+++ b/test/Requests/FunctionsTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace FlixTech\SchemaRegistryApi\Test\Requests;
 
-use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectRequest;
-use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectVersionRequest;
 use PHPUnit\Framework\TestCase;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_FORWARD;
@@ -19,6 +17,8 @@ use function FlixTech\SchemaRegistryApi\Requests\changeSubjectCompatibilityLevel
 use function FlixTech\SchemaRegistryApi\Requests\checkIfSubjectHasSchemaRegisteredRequest;
 use function FlixTech\SchemaRegistryApi\Requests\checkSchemaCompatibilityAgainstVersionRequest;
 use function FlixTech\SchemaRegistryApi\Requests\defaultCompatibilityLevelRequest;
+use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectRequest;
+use function FlixTech\SchemaRegistryApi\Requests\deleteSubjectVersionRequest;
 use function FlixTech\SchemaRegistryApi\Requests\prepareCompatibilityLevelForTransport;
 use function FlixTech\SchemaRegistryApi\Requests\prepareJsonSchemaForTransfer;
 use function FlixTech\SchemaRegistryApi\Requests\registerNewSchemaVersionWithSubjectRequest;


### PR DESCRIPTION
From confluent platform version 3.3 the schema registry supports deletion of subjects and specific versions.

See https://docs.confluent.io/current/schema-registry/docs/schema-deletion-guidelines.html for more information.

This should regularly be used in the development cycle, but there are some appropriate production use cases:

* A new schema to be registered has compatibility issues with one of the
  existing schema versions
* An old version of the schema needs to be registered again for the same
  subject
* The schema’s are used only in real-time streaming systems and the
  older version(s) are absolutely no longer required
* A topic needs to be recycled