### PR TITLE
[CI] Optimize `bin/ci` script

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,8 +1,12 @@
-echo "Running php-cs-fixer in dry run..." && \
-./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --ansi --dry-run && \
+#!/usr/bin/env sh
 
-echo "Running unit tests..." && \
-./vendor/bin/phpunit -v --exclude-group integration --coverage-text && \
+set -e
 
-echo "Running static analysis..." && \
+echo "Running php-cs-fixer in dry run..."
+./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --ansi --dry-run
+
+echo "Running unit tests..."
+./vendor/bin/phpunit -v --exclude-group integration --coverage-text
+
+echo "Running static analysis..."
 ./vendor/bin/phpstan analyse src test --level 0


### PR DESCRIPTION
Use `set -e` and single commands over concatenating commands with `&&`