### PR TITLE
[CI] Add PHP 7.2 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 php:
   - '7.0'
   - '7.1'
+  - '7.2'
   - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require-dev": {
     "phpunit/phpunit": "~6.2",
     "friendsofphp/php-cs-fixer": "~2.0",
-    "phpstan/phpstan": "~0.7",
+    "phpstan/phpstan": "~0.8",
     "raphhh/trex-reflection": "~1.0",
     "doctrine/cache": "~1.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "~7.0",
-    "guzzlehttp/guzzle": "~6.2",
+    "guzzlehttp/guzzle": "~6.3",
     "beberlei/assert": "~2.7",
     "rg/avro-php": "~1.8"
   },


### PR DESCRIPTION
Since PHP 7.2 will be soon out of the oven we should start testing against 7.2 and support it.