### PR TITLE
 [FEATURE][BC-BREAK] Add possibility to cache schema IDs by hash

### DIFF
--- a/src/Registry/Cache/AvroObjectCacheAdapter.php
+++ b/src/Registry/Cache/AvroObjectCacheAdapter.php
@@ -18,6 +18,11 @@ class AvroObjectCacheAdapter implements CacheAdapter
     private $idToSchema = [];
 
     /**
+     * @var int[]
+     */
+    private $hashToSchemaId = [];
+
+    /**
      * @var AvroSchema[]
      */
     private $subjectVersionToSchema = [];
@@ -28,6 +33,14 @@ class AvroObjectCacheAdapter implements CacheAdapter
     public function cacheSchemaWithId(AvroSchema $schema, int $schemaId)
     {
         $this->idToSchema[$schemaId] = $schema;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash)
+    {
+        $this->hashToSchemaId[$schemaHash] = $schemaId;
     }
 
     /**
@@ -50,6 +63,15 @@ class AvroObjectCacheAdapter implements CacheAdapter
         return $this->idToSchema[$schemaId];
     }
 
+    public function getIdWithHash(string $hash)
+    {
+        if (!$this->hasSchemaIdForHash($hash)) {
+            return null;
+        }
+
+        return $this->hashToSchemaId[$hash];
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -70,6 +92,14 @@ class AvroObjectCacheAdapter implements CacheAdapter
     public function hasSchemaForId(int $schemaId): bool
     {
         return array_key_exists($schemaId, $this->idToSchema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaIdForHash(string $schemaHash): bool
+    {
+        return array_key_exists($schemaHash, $this->hashToSchemaId);
     }
 
     /**

--- a/src/Registry/Cache/DoctrineCacheAdapter.php
+++ b/src/Registry/Cache/DoctrineCacheAdapter.php
@@ -31,6 +31,11 @@ class DoctrineCacheAdapter implements CacheAdapter
         $this->doctrineCache->save($schemaId, (string) $schema);
     }
 
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash)
+    {
+        $this->doctrineCache->save($schemaHash, $schemaId);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -59,6 +64,20 @@ class DoctrineCacheAdapter implements CacheAdapter
     /**
      * {@inheritdoc}
      */
+    public function getIdWithHash(string $hash)
+    {
+        $schemaId = $this->doctrineCache->fetch($hash);
+
+        if (!$schemaId) {
+            return null;
+        }
+
+        return $schemaId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getWithSubjectAndVersion(string $subject, int $version)
     {
         $rawSchema = $this->doctrineCache->fetch(
@@ -80,6 +99,14 @@ class DoctrineCacheAdapter implements CacheAdapter
     public function hasSchemaForId(int $schemaId): bool
     {
         return $this->doctrineCache->contains($schemaId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaIdForHash(string $schemaHash): bool
+    {
+        return $this->doctrineCache->contains($schemaHash);
     }
 
     /**

--- a/src/Registry/CacheAdapter.php
+++ b/src/Registry/CacheAdapter.php
@@ -33,6 +33,16 @@ interface CacheAdapter
     public function cacheSchemaWithSubjectAndVersion(AvroSchema $schema, string $subject, int $version);
 
     /**
+     * Caches a schema id by a hash (i.e. the hash of the Avro schema string representation)
+     *
+     * @param int $schemaId
+     * @param string $schemaHash
+     *
+     * @return void
+     */
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash);
+
+    /**
      * Tries to fetch a cache with the global schema id.
      * Returns either the AvroSchema when found or `null` when not.
      *
@@ -41,6 +51,16 @@ interface CacheAdapter
      * @return AvroSchema|null
      */
     public function getWithId(int $schemaId);
+
+    /**
+     * Tries to fetch a cached schema id with a given hash.
+     * Either returns the schema id as int or `null` when none is found.
+     *
+     * @param string $hash
+     *
+     * @return int|null
+     */
+    public function getIdWithHash(string $hash);
 
     /**
      * Tries to fetch a cache with a given subject and version.
@@ -61,6 +81,15 @@ interface CacheAdapter
      * @return bool
      */
     public function hasSchemaForId(int $schemaId): bool;
+
+    /**
+     * Checks if a schema id exists for the given hash
+     *
+     * @param string $schemaHash
+     *
+     * @return bool
+     */
+    public function hasSchemaIdForHash(string $schemaHash): bool;
 
     /**
      * Checks if the cache engine has a cached schema for a given subject and version.

--- a/test/Registry/Cache/AbstractCacheAdapterTestCase.php
+++ b/test/Registry/Cache/AbstractCacheAdapterTestCase.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\SchemaRegistryApi\Test\Registry\Cache;
+
+use AvroSchema;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractCacheAdapterTestCase extends TestCase
+{
+    abstract protected function getAdapter(): CacheAdapter;
+
+    /**
+     * @var CacheAdapter
+     */
+    protected $cacheAdapter;
+
+    protected function setUp()
+    {
+        $this->cacheAdapter = $this->getAdapter();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_and_fetch_schemas_with_ids()
+    {
+        $schemaId = 3;
+        $invalidSchemaId = 2;
+        $schema = AvroSchema::parse('{"type": "string"}');
+
+        $this->cacheAdapter->cacheSchemaWithId($schema, $schemaId);
+
+        $this->assertFalse($this->cacheAdapter->hasSchemaForId($invalidSchemaId));
+        $this->assertTrue($this->cacheAdapter->hasSchemaForId($schemaId));
+
+        $this->assertNull($this->cacheAdapter->getWithId($invalidSchemaId));
+        $this->assertEquals($schema, $this->cacheAdapter->getWithId($schemaId));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_and_fetch_schemas_with_subject_and_version()
+    {
+        $subject = 'test';
+        $version = 2;
+        $invalidSubject = 'none';
+        $schema = AvroSchema::parse('{"type": "string"}');
+
+        $this->cacheAdapter->cacheSchemaWithSubjectAndVersion($schema, $subject, $version);
+
+        $this->assertFalse($this->cacheAdapter->hasSchemaForSubjectAndVersion($invalidSubject, $version));
+        $this->assertTrue($this->cacheAdapter->hasSchemaForSubjectAndVersion($subject, $version));
+
+        $this->assertNull($this->cacheAdapter->getWithSubjectAndVersion($invalidSubject, $version));
+        $this->assertEquals($schema, $this->cacheAdapter->getWithSubjectAndVersion($subject, $version));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_and_fetch_schema_ids_with_schema_hashes()
+    {
+        $schemaId = 3;
+        $hash = 'hash';
+        $anotherHash = 'another';
+
+        $this->assertFalse($this->cacheAdapter->hasSchemaIdForHash($hash));
+        $this->assertFalse($this->cacheAdapter->hasSchemaIdForHash($anotherHash));
+
+        $this->cacheAdapter->cacheSchemaIdByHash($schemaId, $hash);
+
+        $this->assertTrue($this->cacheAdapter->hasSchemaIdForHash($hash));
+        $this->assertFalse($this->cacheAdapter->hasSchemaIdForHash($anotherHash));
+
+        $this->assertNull($this->cacheAdapter->getIdWithHash($anotherHash));
+        $this->assertSame($schemaId, $this->cacheAdapter->getIdWithHash($hash));
+    }
+}

--- a/test/Registry/Cache/AvroObjectCacheAdapterTest.php
+++ b/test/Registry/Cache/AvroObjectCacheAdapterTest.php
@@ -4,56 +4,13 @@ declare(strict_types=1);
 
 namespace FlixTech\SchemaRegistryApi\Test\Registry\Cache;
 
-use AvroSchema;
 use FlixTech\SchemaRegistryApi\Registry\Cache\AvroObjectCacheAdapter;
-use PHPUnit\Framework\TestCase;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
 
-class AvroObjectCacheAdapterTest extends TestCase
+class AvroObjectCacheAdapterTest extends AbstractCacheAdapterTestCase
 {
-    /**
-     * @var \FlixTech\SchemaRegistryApi\Registry\Cache\AvroObjectCacheAdapter
-     */
-    private $cacheAdapter;
-
-    protected function setUp()
+    protected function getAdapter(): CacheAdapter
     {
-        $this->cacheAdapter = new AvroObjectCacheAdapter();
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_store_and_fetch_schemas_with_ids()
-    {
-        $schemaId = 3;
-        $invalidSchemaId = 2;
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->cacheAdapter->cacheSchemaWithId($schema, $schemaId);
-
-        $this->assertFalse($this->cacheAdapter->hasSchemaForId($invalidSchemaId));
-        $this->assertTrue($this->cacheAdapter->hasSchemaForId($schemaId));
-
-        $this->assertNull($this->cacheAdapter->getWithId($invalidSchemaId));
-        $this->assertEquals($schema, $this->cacheAdapter->getWithId($schemaId));
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_store_and_fetch_schemas_with_subject_and_version()
-    {
-        $subject = 'test';
-        $version = 2;
-        $invalidSubject = 'none';
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->cacheAdapter->cacheSchemaWithSubjectAndVersion($schema, $subject, $version);
-
-        $this->assertFalse($this->cacheAdapter->hasSchemaForSubjectAndVersion($invalidSubject, $version));
-        $this->assertTrue($this->cacheAdapter->hasSchemaForSubjectAndVersion($subject, $version));
-
-        $this->assertNull($this->cacheAdapter->getWithSubjectAndVersion($invalidSubject, $version));
-        $this->assertEquals($schema, $this->cacheAdapter->getWithSubjectAndVersion($subject, $version));
+        return new AvroObjectCacheAdapter();
     }
 }

--- a/test/Registry/Cache/DoctrineCacheAdapterTest.php
+++ b/test/Registry/Cache/DoctrineCacheAdapterTest.php
@@ -4,132 +4,14 @@ declare(strict_types=1);
 
 namespace FlixTech\SchemaRegistryApi\Test\Registry\Cache;
 
-use AvroSchema;
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\ArrayCache;
 use FlixTech\SchemaRegistryApi\Registry\Cache\DoctrineCacheAdapter;
-use PHPUnit\Framework\TestCase;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
 
-class DoctrineCacheAdapterTest extends TestCase
+class DoctrineCacheAdapterTest extends AbstractCacheAdapterTestCase
 {
-    /**
-     * @var Cache|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $doctrineCache;
-
-    /**
-     * @var DoctrineCacheAdapter
-     */
-    private $cacheAdapter;
-
-    protected function setUp()
+    protected function getAdapter(): CacheAdapter
     {
-        $this->doctrineCache = $this->getMockForAbstractClass(Cache::class);
-        $this->cacheAdapter = new DoctrineCacheAdapter($this->doctrineCache);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_store_schemas_with_ids()
-    {
-        $schemaId = 3;
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->doctrineCache
-            ->expects($this->once())
-            ->method('save')
-            ->with(3, (string) $schema);
-
-        $this->cacheAdapter->cacheSchemaWithId($schema, $schemaId);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_fetch_schemas_with_id()
-    {
-        $schemaId = 3;
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->doctrineCache
-            ->expects($this->exactly(2))
-            ->method('fetch')
-            ->with($schemaId)
-            ->willReturnOnConsecutiveCalls((string) $schema, null);
-
-        $this->assertEquals($schema, $this->cacheAdapter->getWithId($schemaId));
-        $this->assertNull($this->cacheAdapter->getWithId($schemaId));
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_check_if_a_schema_exists_for_id()
-    {
-        $schemaId = 3;
-
-        $this->doctrineCache
-            ->expects($this->once())
-            ->method('contains')
-            ->with($schemaId)
-            ->willReturn(true);
-
-        $this->assertTrue($this->cacheAdapter->hasSchemaForId($schemaId));
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_cache_schemas_by_subject_and_version()
-    {
-        $version = 3;
-        $subject = 'test';
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->doctrineCache
-            ->expects($this->once())
-            ->method('save')
-            ->with($subject . '_' . $version, (string) $schema);
-
-        $this->cacheAdapter->cacheSchemaWithSubjectAndVersion($schema, $subject, $version);
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_fetch_schemas_by_subject_and_version()
-    {
-        $version = 3;
-        $subject = 'test';
-        $schema = AvroSchema::parse('{"type": "string"}');
-
-        $this->doctrineCache
-            ->expects($this->exactly(2))
-            ->method('fetch')
-            ->with($subject . '_' . $version)
-            ->willReturnOnConsecutiveCalls($schema, null);
-
-        $this->assertEquals(
-            $schema,
-            $this->cacheAdapter->getWithSubjectAndVersion($subject, $version)
-        );
-        $this->assertNull($this->cacheAdapter->getWithSubjectAndVersion($subject, $version));
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_check_if_a_schema_exists_for_subject_and_version()
-    {
-        $version = 3;
-        $subject = 'test';
-
-        $this->doctrineCache
-            ->expects($this->once())
-            ->method('contains')
-            ->with($subject . '_' . $version)
-            ->willReturn(true);
-
-        $this->assertTrue($this->cacheAdapter->hasSchemaForSubjectAndVersion($subject, $version));
+        return new DoctrineCacheAdapter(new ArrayCache());
     }
 }


### PR DESCRIPTION
This is needed because when running serializers the cost of hashing the schemas' string representations is way less than going to the registry over HTTP.

This adds 3 new methods to the `CacheAdapter` API:

`cacheSchemaIdByHash(int $schemaId, string $schemaHash)`
`getIdWithHash(string $hash)`
`hasSchemaIdForHash(string $schemaHash)`

Unfortunately this is a BC breaking change which requires clients that possibly have own implementations of the `CacheAdapterInterface` to implement those 3 methods.

Clients that use the default shipped adapters are OK.