### PR TITLE
Replace `flix-tech/avro-php` instead of `rg/avro-php` to fix critical bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ compliant requests that can be used as well as high level abstractions to ease d
 | **`php`** | ~7.0 | Anything lower has reached EOL |
 | **`guzzlephp/guzzle`** | ~6.3 | Using `Request` to build PSR-7 `RequestInterface` |
 | **`beberlei/assert`** | ~2.7 | The de-facto standard assertions library for PHP |
-| **`rg/avro-php`** | ~1.8 | The only Avro PHP implementation I have found so far. |
+| **`flix-tech/avro-php`** | ^2.0 | Maintained fork of the only Avro PHP implementation: `rg/avro-php` |
 
 ### Optional dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,17 @@
       "email": "thomas.ploch@flixbus.com"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:flix-tech/avro-php.git"
+    }
+  ],
   "require": {
     "php": "~7.0",
     "guzzlehttp/guzzle": "~6.3",
     "beberlei/assert": "~2.7",
-    "rg/avro-php": "~1.8"
+    "flix-tech/avro-php": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2",
@@ -24,7 +30,7 @@
     "doctrine/cache": "~1.3"
   },
   "suggest": {
-    "rg/avro-php": "Needed if you want to use the high level registry abstractions",
+    "flix-tech/avro-php": "Needed for decoding and encoding messages in Apache Avro format",
     "raphhh/trex-reflection": "Needed if you want to use the `RequestCallbackValidator`",
     "doctrine/cache": "If you want to use the DoctrineCacheAdapter"
   },


### PR DESCRIPTION
Replace `flix-tech/avro-php` instead of `rg/avro-php` to fix a critical bug.

The bug made it impossible to deserialize binary encoded messages
which contained `array` and `map` data types in their schemas.