### PR TITLE
Increased minimum version for beberlei/assert to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "~7.1",
     "guzzlehttp/guzzle": "~6.3",
-    "beberlei/assert": "~2.7",
+    "beberlei/assert": "~3.0",
     "flix-tech/avro-php": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
In version beberlei/assert 3.0 they deprecated support for PHP < 7.0. I think it would be also useful to change update version constraint here.