### PR TITLE
Add support for psr cache interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ compliant requests that can be used as well as high level abstractions to ease d
 | Dependency | Version | Reason |
 |:--- |:---:|:--- |
 | **`doctrine/cache`** | ~1.3 | If you want to use the `DoctrineCacheAdapter` |
+| **`psr/cache`** | ^1.0 | If you want to use the `CacheItemPoolAdapter` |
+| **`psr/simple-cache`** | ^1.0 | If you want to use the `SimpleCacheAdapter` |
 | **`raphhh/trex-reflection`** | ~1.0 | If you want to use the `RequestCallbackValidator`s |
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "ext-curl": "*",
     "ext-json": "*",
     "guzzlehttp/guzzle": "~6.3",
+    "guzzlehttp/psr7": "<1.7",
     "beberlei/assert": "~2.7|~3.0",
     "flix-tech/avro-php": "^3.0|^4.0"
   },
@@ -22,11 +23,16 @@
     "phpunit/phpunit": "~7.0",
     "phpstan/phpstan": "^0.12",
     "raphhh/trex-reflection": "~1.0",
-    "doctrine/cache": "~1.3"
+    "doctrine/cache": "~1.3",
+    "psr/cache": "^1.0",
+    "symfony/cache": "^5.1",
+    "psr/simple-cache": "^1.0"
   },
   "suggest": {
     "raphhh/trex-reflection": "Needed if you want to use the `RequestCallbackValidator`",
-    "doctrine/cache": "If you want to use the DoctrineCacheAdapter"
+    "doctrine/cache": "If you want to use the DoctrineCacheAdapter",
+    "psr/cache": "If you want to use the CacheItemPoolAdapter",
+    "psr/simple-cache": "If you want to use the SimpleCacheAdapter"
   },
   "autoload": {
     "psr-4": {

--- a/src/Registry/Cache/CacheItemPoolAdapter.php
+++ b/src/Registry/Cache/CacheItemPoolAdapter.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\SchemaRegistryApi\Registry\Cache;
+
+use AvroSchema;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CacheItemPoolAdapter implements CacheAdapter
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cacheItemPool;
+
+    public function __construct(CacheItemPoolInterface $cacheItemPool)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaWithId(AvroSchema $schema, int $schemaId): void
+    {
+        $item = $this->cacheItemPool->getItem((string) $schemaId);
+        $item->set((string) $schema);
+        $this->cacheItemPool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash): void
+    {
+        $item = $this->cacheItemPool->getItem($schemaHash);
+        $item->set($schemaId);
+        $this->cacheItemPool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaWithSubjectAndVersion(AvroSchema $schema, string $subject, int $version): void
+    {
+        $item = $this->cacheItemPool->getItem($this->makeKeyFromSubjectAndVersion($subject, $version));
+        $item->set((string) $schema);
+        $this->cacheItemPool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \AvroSchemaParseException
+     */
+    public function getWithId(int $schemaId): ?AvroSchema
+    {
+        $item = $this->cacheItemPool->getItem((string) $schemaId);
+
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        $rawSchema = $item->get();
+
+        return AvroSchema::parse($rawSchema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdWithHash(string $hash): ?int
+    {
+        $item = $this->cacheItemPool->getItem($hash);
+
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        return $item->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \AvroSchemaParseException
+     */
+    public function getWithSubjectAndVersion(string $subject, int $version): ?AvroSchema
+    {
+        $item = $this->cacheItemPool->getItem(
+            $this->makeKeyFromSubjectAndVersion($subject, $version)
+        );
+
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        $rawSchema = $item->get();
+
+        return AvroSchema::parse($rawSchema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaForId(int $schemaId): bool
+    {
+        return $this->cacheItemPool
+            ->getItem((string) $schemaId)
+            ->isHit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaIdForHash(string $schemaHash): bool
+    {
+        return $this->cacheItemPool
+            ->getItem($schemaHash)
+            ->isHit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaForSubjectAndVersion(string $subject, int $version): bool
+    {
+        return $this->cacheItemPool
+            ->getItem(
+                $this->makeKeyFromSubjectAndVersion($subject, $version)
+            )
+            ->isHit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function makeKeyFromSubjectAndVersion(string $subject, int $version): string
+    {
+        return sprintf('%s_%d', $subject, $version);
+    }
+}

--- a/src/Registry/Cache/SimpleCacheAdapter.php
+++ b/src/Registry/Cache/SimpleCacheAdapter.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\SchemaRegistryApi\Registry\Cache;
+
+use AvroSchema;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
+use Psr\SimpleCache\CacheInterface;
+
+class SimpleCacheAdapter implements CacheAdapter
+{
+    /**
+     * @var CacheInterface $cache
+     */
+    private $cache;
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaWithId(AvroSchema $schema, int $schemaId): void
+    {
+        $this->cache->set((string) $schemaId, (string) $schema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash): void
+    {
+        $this->cache->set($schemaHash, $schemaId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheSchemaWithSubjectAndVersion(AvroSchema $schema, string $subject, int $version): void
+    {
+        $this->cache->set(
+            $this->makeKeyFromSubjectAndVersion($subject, $version),
+            (string) $schema
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \AvroSchemaParseException
+     */
+    public function getWithId(int $schemaId): ?AvroSchema
+    {
+        $rawSchema = $this->cache->get((string) $schemaId);
+
+        if (null === $rawSchema) {
+            return null;
+        }
+
+        return AvroSchema::parse($rawSchema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdWithHash(string $hash): ?int
+    {
+
+        return $this->cache->get($hash);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \AvroSchemaParseException
+     */
+    public function getWithSubjectAndVersion(string $subject, int $version): ?AvroSchema
+    {
+        $rawSchema = $this->cache->get(
+            $this->makeKeyFromSubjectAndVersion($subject, $version)
+        );
+
+        if (null === $rawSchema) {
+            return null;
+        }
+
+        return AvroSchema::parse($rawSchema);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaForId(int $schemaId): bool
+    {
+        return null !== $this->cache->get((string) $schemaId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaIdForHash(string $schemaHash): bool
+    {
+        return null !== $this->cache->get($schemaHash);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaForSubjectAndVersion(string $subject, int $version): bool
+    {
+        $schema = $this->cache->get(
+            $this->makeKeyFromSubjectAndVersion($subject, $version)
+        );
+
+        return null !== $schema;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function makeKeyFromSubjectAndVersion(string $subject, int $version): string
+    {
+        return sprintf('%s_%d', $subject, $version);
+    }
+}

--- a/test/Registry/Cache/CacheItemPoolAdapterTest.php
+++ b/test/Registry/Cache/CacheItemPoolAdapterTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\SchemaRegistryApi\Test\Registry\Cache;
+
+use FlixTech\SchemaRegistryApi\Registry\Cache\CacheItemPoolAdapter;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CacheItemPoolAdapterTest extends AbstractCacheAdapterTestCase
+{
+    protected function getAdapter(): CacheAdapter
+    {
+        return new CacheItemPoolAdapter(new ArrayAdapter());
+    }
+}

--- a/test/Registry/Cache/SimpleCacheAdapterTest.php
+++ b/test/Registry/Cache/SimpleCacheAdapterTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\SchemaRegistryApi\Test\Registry\Cache;
+
+use FlixTech\SchemaRegistryApi\Registry\Cache\SimpleCacheAdapter;
+use FlixTech\SchemaRegistryApi\Registry\CacheAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+class SimpleCacheAdapterTest extends AbstractCacheAdapterTestCase
+{
+    protected function getAdapter(): CacheAdapter
+    {
+        return new SimpleCacheAdapter(new Psr16Cache(new ArrayAdapter()));
+    }
+}


### PR DESCRIPTION
This PR adds support for the PSR cache interfaces.

This adds up a lot of possibilities and flexibility regarding caching options to the package, for example, the symfony/cache project (that implements the interfaces) [provides us with at least 12 adapters](https://symfony.com/doc/current/components/cache.html#available-cache-adapters). Not to mention[ all the others implementations of this standard](https://packagist.org/providers/psr/cache-implementation).

Besides PSR-6, I've also implemented the adapter for PSR-16 (SimpleCache).