### PR TITLE
Guzzle7 with uri template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
     "php": "^7.3|^8.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~6.3",
+    "guzzlehttp/guzzle": "^7.0",
     "guzzlehttp/promises": "^1.4.0",
-    "guzzlehttp/psr7": "<1.7",
+    "guzzlehttp/psr7": "^1.7",
     "beberlei/assert": "~2.7|~3.0",
-    "flix-tech/avro-php": "^4.1"
+    "flix-tech/avro-php": "^4.1",
+    "guzzlehttp/uri-template": "^0.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.2.3|^9.4.2",

--- a/src/Requests/Functions.php
+++ b/src/Requests/Functions.php
@@ -5,7 +5,7 @@ namespace FlixTech\SchemaRegistryApi\Requests;
 use Assert\Assert;
 use FlixTech\SchemaRegistryApi\Schema\AvroReference;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\UriTemplate;
+use GuzzleHttp\UriTemplate\UriTemplate;
 use Psr\Http\Message\RequestInterface;
 use const FlixTech\SchemaRegistryApi\Constants\ACCEPT_HEADER;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -14,7 +14,7 @@ use FlixTech\SchemaRegistryApi\Exception\VersionNotFoundException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\UriTemplate;
+use GuzzleHttp\UriTemplate\UriTemplate;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;


### PR DESCRIPTION
This PR hopes to address issue #55 and #57. It appeared that the main blocker was the removal of the UriTemplate class out of Guzzle7. That specific class was added back as its own repository by the Guzzle team, which I was able to add and it integrated pretty seamlessly. I was able to run all the tests including the docker integration tests and all of them passed.
This is my first PR to an open source repo so I apologize in advance for any errors on my part, I'm happy to make any recommended changes.
Thanks!