### PR TITLE
Fix SimpleCacheAdapter to fix exception caused when the store returns a string of the numeric value

### DIFF
--- a/src/Registry/Cache/SimpleCacheAdapter.php
+++ b/src/Registry/Cache/SimpleCacheAdapter.php
@@ -76,8 +76,13 @@ class SimpleCacheAdapter implements CacheAdapter
      */
     public function getIdWithHash(string $hash): ?int
     {
-
-        return $this->cache->get($hash);
+        $rawId = $this->cache->get($hash);
+        
+        if (null === $rawId) {
+            return null;
+        }
+        
+        return (int) $rawId;
     }
 
     /**


### PR DESCRIPTION
When using `SimpleCacheAdapter` with the Laravel Redis cache adapter, the method `getIdWithHash` tries to return the string representation of the value in the store directly. Giving the following exception ```Symfony\Component\Debug\Exception\FatalThrowableError with message 'Return value of FlixTech\SchemaRegistryApi\Registry\Cache\SimpleCacheAdapter::getIdWithHash() must be of the type int or null, string returned'```