### PR TITLE
support non-root paths in base_uri

### DIFF
--- a/src/Requests/Functions.php
+++ b/src/Requests/Functions.php
@@ -23,7 +23,7 @@ function allSubjectsRequest(): RequestInterface
 {
     return new Request(
         'GET',
-        '/subjects',
+        'subjects',
         ACCEPT_HEADER
     );
 }
@@ -32,7 +32,7 @@ function allSubjectVersionsRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('/subjects/{name}/versions', ['name' => $subjectName]),
+        (new UriTemplate())->expand('subjects/{name}/versions', ['name' => $subjectName]),
         ACCEPT_HEADER
     );
 }
@@ -42,7 +42,7 @@ function singleSubjectVersionRequest(string $subjectName, string $versionId): Re
     return new Request(
         'GET',
         (new UriTemplate())->expand(
-            '/subjects/{name}/versions/{id}',
+            'subjects/{name}/versions/{id}',
             ['name' => $subjectName, 'id' => $versionId]
         ),
         ACCEPT_HEADER
@@ -53,7 +53,7 @@ function registerNewSchemaVersionWithSubjectRequest(string $schema, string $subj
 {
     return new Request(
         'POST',
-        (new UriTemplate())->expand('/subjects/{name}/versions', ['name' => $subjectName]),
+        (new UriTemplate())->expand('subjects/{name}/versions', ['name' => $subjectName]),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
         prepareJsonSchemaForTransfer(validateSchemaStringAsJson($schema), ...$references)
     );
@@ -64,7 +64,7 @@ function checkSchemaCompatibilityAgainstVersionRequest(string $schema, string $s
     return new Request(
         'POST',
         (new UriTemplate())->expand(
-            '/compatibility/subjects/{name}/versions/{version}',
+            'compatibility/subjects/{name}/versions/{version}',
             ['name' => $subjectName, 'version' => $versionId]
         ),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
@@ -76,7 +76,7 @@ function checkIfSubjectHasSchemaRegisteredRequest(string $subjectName, string $s
 {
     return new Request(
         'POST',
-        (new UriTemplate())->expand('/subjects/{name}', ['name' => $subjectName]),
+        (new UriTemplate())->expand('subjects/{name}', ['name' => $subjectName]),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
         prepareJsonSchemaForTransfer(validateSchemaStringAsJson($schema))
     );
@@ -86,7 +86,7 @@ function schemaRequest(string $id): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('/schemas/ids/{id}', ['id' => $id]),
+        (new UriTemplate())->expand('schemas/ids/{id}', ['id' => $id]),
         ACCEPT_HEADER
     );
 }
@@ -95,7 +95,7 @@ function defaultCompatibilityLevelRequest(): RequestInterface
 {
     return new Request(
         'GET',
-        '/config',
+        'config',
         ACCEPT_HEADER
     );
 }
@@ -104,7 +104,7 @@ function changeDefaultCompatibilityLevelRequest(string $level): RequestInterface
 {
     return new Request(
         'PUT',
-        '/config',
+        'config',
         ACCEPT_HEADER,
         prepareCompatibilityLevelForTransport(validateCompatibilityLevel($level))
     );
@@ -114,7 +114,7 @@ function subjectCompatibilityLevelRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('/config/{subject}', ['subject' => $subjectName]),
+        (new UriTemplate())->expand('config/{subject}', ['subject' => $subjectName]),
         ACCEPT_HEADER
     );
 }
@@ -123,7 +123,7 @@ function changeSubjectCompatibilityLevelRequest(string $subjectName, string $lev
 {
     return new Request(
         'PUT',
-        (new UriTemplate())->expand('/config/{subject}', ['subject' => $subjectName]),
+        (new UriTemplate())->expand('config/{subject}', ['subject' => $subjectName]),
         ACCEPT_HEADER,
         prepareCompatibilityLevelForTransport(validateCompatibilityLevel($level))
     );
@@ -208,7 +208,7 @@ function deleteSubjectRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'DELETE',
-        (new UriTemplate())->expand('/subjects/{name}', ['name' => $subjectName]),
+        (new UriTemplate())->expand('subjects/{name}', ['name' => $subjectName]),
         ACCEPT_HEADER
     );
 }
@@ -222,7 +222,7 @@ function deleteSubjectVersionRequest(string $subjectName, string $versionId): Re
 {
     return new Request(
         'DELETE',
-        (new UriTemplate())->expand('/subjects/{name}/versions/{version}', ['name' => $subjectName, 'version' => $versionId]),
+        (new UriTemplate())->expand('subjects/{name}/versions/{version}', ['name' => $subjectName, 'version' => $versionId]),
         ACCEPT_HEADER
     );
 }

--- a/test/Requests/FunctionsTest.php
+++ b/test/Requests/FunctionsTest.php
@@ -51,7 +51,7 @@ class FunctionsTest extends TestCase
         $request = allSubjectsRequest();
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/subjects', $request->getUri());
+        self::assertEquals('subjects', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -63,7 +63,7 @@ class FunctionsTest extends TestCase
         $request = allSubjectVersionsRequest('test');
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/subjects/test/versions', $request->getUri());
+        self::assertEquals('subjects/test/versions', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -75,7 +75,7 @@ class FunctionsTest extends TestCase
         $request = singleSubjectVersionRequest('test', '3');
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/subjects/test/versions/3', $request->getUri());
+        self::assertEquals('subjects/test/versions/3', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -92,7 +92,7 @@ class FunctionsTest extends TestCase
         $request = registerNewSchemaVersionWithSubjectRequest($initialSchema, 'test', ...$references);
 
         self::assertEquals('POST', $request->getMethod());
-        self::assertEquals('/subjects/test/versions', $request->getUri());
+        self::assertEquals('subjects/test/versions', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
         self::assertEquals(CONTENT_TYPE_HEADER[CONTENT_TYPE_HEADER_KEY], $request->getHeader(CONTENT_TYPE_HEADER_KEY)[0]);
         self::assertJsonStringEqualsJsonString($finalSchema, $request->getBody()->getContents());
@@ -143,7 +143,7 @@ JSON,
         );
 
         self::assertEquals('POST', $request->getMethod());
-        self::assertEquals('/compatibility/subjects/test/versions/latest', $request->getUri());
+        self::assertEquals('compatibility/subjects/test/versions/latest', $request->getUri());
         self::assertEquals('{"schema":"{\"type\":\"test\"}"}', $request->getBody()->getContents());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
         self::assertEquals(CONTENT_TYPE_HEADER[CONTENT_TYPE_HEADER_KEY], $request->getHeader(CONTENT_TYPE_HEADER_KEY)[0]);
@@ -157,7 +157,7 @@ JSON,
         $request = checkIfSubjectHasSchemaRegisteredRequest('test', '{"type":"test"}');
 
         self::assertEquals('POST', $request->getMethod());
-        self::assertEquals('/subjects/test', $request->getUri());
+        self::assertEquals('subjects/test', $request->getUri());
         self::assertEquals('{"schema":"{\"type\":\"test\"}"}', $request->getBody()->getContents());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
         self::assertEquals(CONTENT_TYPE_HEADER[CONTENT_TYPE_HEADER_KEY], $request->getHeader(CONTENT_TYPE_HEADER_KEY)[0]);
@@ -171,7 +171,7 @@ JSON,
         $request = schemaRequest('3');
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/schemas/ids/3', $request->getUri());
+        self::assertEquals('schemas/ids/3', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -183,7 +183,7 @@ JSON,
         $request = defaultCompatibilityLevelRequest();
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/config', $request->getUri());
+        self::assertEquals('config', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -195,7 +195,7 @@ JSON,
         $request = changeDefaultCompatibilityLevelRequest(COMPATIBILITY_FULL);
 
         self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/config', $request->getUri());
+        self::assertEquals('config', $request->getUri());
         self::assertEquals('{"compatibility":"FULL"}', $request->getBody()->getContents());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
@@ -208,7 +208,7 @@ JSON,
         $request = subjectCompatibilityLevelRequest('test');
 
         self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/config/test', $request->getUri());
+        self::assertEquals('config/test', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -220,7 +220,7 @@ JSON,
         $request = changeSubjectCompatibilityLevelRequest('test', COMPATIBILITY_FORWARD);
 
         self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/config/test', $request->getUri());
+        self::assertEquals('config/test', $request->getUri());
         self::assertEquals('{"compatibility":"FORWARD"}', $request->getBody()->getContents());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
@@ -384,7 +384,7 @@ JSON,
         $request = deleteSubjectRequest('test');
 
         self::assertEquals('DELETE', $request->getMethod());
-        self::assertEquals('/subjects/test', $request->getUri());
+        self::assertEquals('subjects/test', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 
@@ -396,13 +396,13 @@ JSON,
         $request = deleteSubjectVersionRequest('test', VERSION_LATEST);
 
         self::assertEquals('DELETE', $request->getMethod());
-        self::assertEquals('/subjects/test/versions/latest', $request->getUri());
+        self::assertEquals('subjects/test/versions/latest', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
 
         $request = deleteSubjectVersionRequest('test', '5');
 
         self::assertEquals('DELETE', $request->getMethod());
-        self::assertEquals('/subjects/test/versions/5', $request->getUri());
+        self::assertEquals('subjects/test/versions/5', $request->getUri());
         self::assertEquals(ACCEPT_HEADER[ACCEPT_HEADER_KEY], $request->getHeader(ACCEPT_HEADER_KEY)[0]);
     }
 }


### PR DESCRIPTION
resolves #61

Given a Guzzle client with a base uri like
`http://example.com/myregistryliveshere/`.

Requests where created with a relative path with a leading `/`.
Guzzle interprets this as a path from the root and replaces
`/myregistryliveshere/` with the given path.

To make Guzzle combine the path correctly with the given
base_uri, the relative path must not start with a `/`. Then
it is appended at the end of the base_uri, preserving the
path in the base_uri.