### PR TITLE
Add Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "php": "^7.3|^8.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~6.3",
+    "guzzlehttp/guzzle": "~6.3|^7.0",
     "guzzlehttp/promises": "^1.4.0",
-    "guzzlehttp/psr7": "<1.7",
+    "guzzlehttp/psr7": "^1.7",
     "beberlei/assert": "~2.7|~3.0",
     "flix-tech/avro-php": "^4.1"
   },

--- a/src/Exception/ExceptionMap.php
+++ b/src/Exception/ExceptionMap.php
@@ -74,7 +74,7 @@ final class ExceptionMap
         try {
             $decodedBody = \GuzzleHttp\json_decode((string) $response->getBody(), true);
 
-            if (!array_key_exists(self::ERROR_CODE_FIELD_NAME, $decodedBody)) {
+            if (!is_array($decodedBody) || !array_key_exists(self::ERROR_CODE_FIELD_NAME, $decodedBody)) {
                 throw new RuntimeException(
                     sprintf(
                         'Invalid message body received - cannot find "error_code" field in response body "%s"',

--- a/src/Registry/PromisingRegistry.php
+++ b/src/Registry/PromisingRegistry.php
@@ -174,7 +174,15 @@ class PromisingRegistry implements AsynchronousRegistry
         $body = (string) $response->getBody();
 
         try {
-            return \GuzzleHttp\json_decode($body, true);
+            $decoded = \GuzzleHttp\json_decode($body, true);
+
+            if (!is_array($decoded)) {
+                throw new InvalidArgumentException(
+                    sprintf('response content "%s" is not a valid json object', $body)
+                );
+            }
+
+            return $decoded;
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException(
                 sprintf('%s - with content "%s"', $e->getMessage(), $body),

--- a/src/Requests/Functions.php
+++ b/src/Requests/Functions.php
@@ -5,7 +5,6 @@ namespace FlixTech\SchemaRegistryApi\Requests;
 use Assert\Assert;
 use FlixTech\SchemaRegistryApi\Schema\AvroReference;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\UriTemplate;
 use Psr\Http\Message\RequestInterface;
 use const FlixTech\SchemaRegistryApi\Constants\ACCEPT_HEADER;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;
@@ -32,7 +31,7 @@ function allSubjectVersionsRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('subjects/{name}/versions', ['name' => $subjectName]),
+        sprintf('subjects/%s/versions', $subjectName),
         ACCEPT_HEADER
     );
 }
@@ -41,9 +40,10 @@ function singleSubjectVersionRequest(string $subjectName, string $versionId): Re
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand(
-            'subjects/{name}/versions/{id}',
-            ['name' => $subjectName, 'id' => $versionId]
+        sprintf(
+            'subjects/%s/versions/%s',
+            $subjectName,
+            $versionId,
         ),
         ACCEPT_HEADER
     );
@@ -53,7 +53,7 @@ function registerNewSchemaVersionWithSubjectRequest(string $schema, string $subj
 {
     return new Request(
         'POST',
-        (new UriTemplate())->expand('subjects/{name}/versions', ['name' => $subjectName]),
+        sprintf('subjects/%s/versions', $subjectName),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
         prepareJsonSchemaForTransfer(validateSchemaStringAsJson($schema), ...$references)
     );
@@ -63,9 +63,10 @@ function checkSchemaCompatibilityAgainstVersionRequest(string $schema, string $s
 {
     return new Request(
         'POST',
-        (new UriTemplate())->expand(
-            'compatibility/subjects/{name}/versions/{version}',
-            ['name' => $subjectName, 'version' => $versionId]
+        sprintf(
+            'compatibility/subjects/%s/versions/%s',
+            $subjectName,
+            $versionId,
         ),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
         prepareJsonSchemaForTransfer(validateSchemaStringAsJson($schema))
@@ -76,7 +77,7 @@ function checkIfSubjectHasSchemaRegisteredRequest(string $subjectName, string $s
 {
     return new Request(
         'POST',
-        (new UriTemplate())->expand('subjects/{name}', ['name' => $subjectName]),
+        sprintf('subjects/%s', $subjectName),
         CONTENT_TYPE_HEADER + ACCEPT_HEADER,
         prepareJsonSchemaForTransfer(validateSchemaStringAsJson($schema))
     );
@@ -86,7 +87,7 @@ function schemaRequest(string $id): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('schemas/ids/{id}', ['id' => $id]),
+        sprintf('schemas/ids/%s', $id),
         ACCEPT_HEADER
     );
 }
@@ -114,7 +115,7 @@ function subjectCompatibilityLevelRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'GET',
-        (new UriTemplate())->expand('config/{subject}', ['subject' => $subjectName]),
+        sprintf('config/%s', $subjectName),
         ACCEPT_HEADER
     );
 }
@@ -123,7 +124,7 @@ function changeSubjectCompatibilityLevelRequest(string $subjectName, string $lev
 {
     return new Request(
         'PUT',
-        (new UriTemplate())->expand('config/{subject}', ['subject' => $subjectName]),
+        sprintf('config/%s', $subjectName),
         ACCEPT_HEADER,
         prepareCompatibilityLevelForTransport(validateCompatibilityLevel($level))
     );
@@ -208,7 +209,7 @@ function deleteSubjectRequest(string $subjectName): RequestInterface
 {
     return new Request(
         'DELETE',
-        (new UriTemplate())->expand('subjects/{name}', ['name' => $subjectName]),
+        sprintf('subjects/%s', $subjectName),
         ACCEPT_HEADER
     );
 }
@@ -222,7 +223,7 @@ function deleteSubjectVersionRequest(string $subjectName, string $versionId): Re
 {
     return new Request(
         'DELETE',
-        (new UriTemplate())->expand('subjects/{name}/versions/{version}', ['name' => $subjectName, 'version' => $versionId]),
+        sprintf('subjects/%s/versions/%s', $subjectName, $versionId),
         ACCEPT_HEADER
     );
 }

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -14,7 +14,6 @@ use FlixTech\SchemaRegistryApi\Exception\VersionNotFoundException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\UriTemplate;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use const FlixTech\SchemaRegistryApi\Constants\COMPATIBILITY_BACKWARD;
@@ -105,12 +104,10 @@ INCOMPATIBLE;
         }
 
         $this->client = new Client([
-            'base_uri' => (new UriTemplate())->expand(
-                'http://{host}:{port}',
-                [
-                    'host' => getenv('TEST_SCHEMA_REGISTRY_HOST'),
-                    'port' => getenv('TEST_SCHEMA_REGISTRY_PORT'),
-                ]
+            'base_uri' => sprintf(
+                'http://%s:%s',
+                getenv('TEST_SCHEMA_REGISTRY_HOST'),
+                getenv('TEST_SCHEMA_REGISTRY_PORT')
             )
         ]);
     }


### PR DESCRIPTION
Once the UriTemplate class was heavily used and it had been removed from
Guzzle 7 it was not possible to add support for the next guzzle major
version.

Replace usages of UriTemplate with sprintf calls and update
composer.json with support for guzzle 7.

Fixes #57
Fixes #55