### PR TITLE
[CI] Upgrade CI dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,13 +29,13 @@ jobs:
         php:
           -
             version: 7.4
-            xdebug: 2.9.8
+            xdebug: 3.1.1
           -
-            version: 7.3
-            xdebug: 2.9.8
+            version: 8.0
+            xdebug: 3.1.1
           -
-            version: rc
-            xdebug: 3.0.0beta1
+            version: 8.1-rc
+            xdebug: 3.1.1
     runs-on: ubuntu-20.04
     steps:
       -
@@ -79,22 +79,22 @@ jobs:
       matrix:
         php:
           -
-            version: 7.3
-            composer: --prefer-lowest
-          -
             version: 7.4
             composer: --prefer-lowest
           -
-            version: rc
+            version: 8.0
             composer: --prefer-lowest
           -
-            version: 7.3
-            composer: --prefer-stable
+            version: 8.1-rc
+            composer: --prefer-lowest
           -
             version: 7.4
             composer: --prefer-stable
           -
-            version: rc
+            version: 8.0
+            composer: --prefer-stable
+          -
+            version: 8.1-rc
             composer: --prefer-stable
     steps:
       -
@@ -127,7 +127,7 @@ jobs:
           chmod a+x bin/phpstan.phar
           docker run -i --rm --net=host --sig-proxy=true --pid=host -m 4000M --entrypoint="php" \
             -v "${GITHUB_WORKSPACE}":"${GITHUB_WORKSPACE}" -w "${GITHUB_WORKSPACE}" schema-registry-client:${{ matrix.php.version }} \
-            -d memory_limit=4G -d xdebug.mode=off -d xdebug.coverage_enable=0 bin/phpstan.phar analyse
+            -d memory_limit=4G -d xdebug.mode=off bin/phpstan.phar analyse
       -
         name: Run CS Fixer
         if: ${{ matrix.php.version == '7.4' && matrix.php.composer == '--prefer-stable' }}
@@ -135,7 +135,7 @@ jobs:
           chmod a+x bin/php-cs-fixer.phar
           docker run -i --rm --net=host --sig-proxy=true --pid=host -m 1000M --entrypoint="php" \
             -v "${GITHUB_WORKSPACE}":"${GITHUB_WORKSPACE}" -w "${GITHUB_WORKSPACE}" schema-registry-client:${{ matrix.php.version }} \
-            -d xdebug.mode=off -d xdebug.coverage_enable=0 bin/php-cs-fixer.phar fix --config=.php_cs.dist \
+            -d xdebug.mode=off -d xdebug.coverage_enable=0 bin/php-cs-fixer.phar fix --config=.php-cs-fixer.dist.php \
             --diff -v --dry-run --path-mode=intersection --allow-risky=yes \
             src test
       -

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ composer.phar
 composer.lock
 
 # Custom entries
-.php_cs*.cache
+.php-cs*.cache
 .env
 variables.mk
 /build/

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,7 +6,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in('src')
     ->in('test');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules(
         [
             'no_unused_imports' => true,

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,30 @@
 # no buildin rules and variables
 MAKEFLAGS =+ -rR --warn-undefined-variables
 
-.PHONY: composer-install composer-update phpstan cs-fixer examples docker run
+.PHONY: *
 
 CONFLUENT_VERSION ?= latest
 CONFLUENT_NETWORK_SUBNET ?= 172.68.0.0/24
+CONFLUENT_NETWORK_GATEWAY ?= 172.68.0.1
 SCHEMA_REGISTRY_IPV4 ?= 172.68.0.103
 KAFKA_BROKER_IPV4 ?= 172.68.0.102
 ZOOKEEPER_IPV4 ?= 172.68.0.101
 COMPOSER ?= bin/composer.phar
-COMPOSER_VERSION ?= 2.0.4
+COMPOSER_VERSION ?= 2.1.12
+COMPOSER_STABILITY ?= --prefer-stable
 PHP_STAN ?= bin/phpstan.phar
-PHP_STAN_VERSION ?= 0.12.53
+PHP_STAN_VERSION ?= 1.1.2
 PHP_CS_FIXER ?= bin/php-cs-fixer.phar
+PHP_CS_FIXER_VERSION ?= 3.2.1
 PHPUNIT ?= vendor/bin/phpunit
 PHP ?= bin/php
-PHP_VERSION ?= 7.3
-XDEBUG_VERSION ?= 2.9.8
-XDEBUG_OPTIONS ?= -d xdebug.mode=off -d xdebug.coverage_enable=0
+PHP_VERSION ?= 7.4
+XDEBUG_VERSION ?= 3.1.1
+XDEBUG_OPTIONS ?= -d xdebug.mode=off
 export
 
 docker:
-	docker build \
+	DOCKER_BUILDKIT=1 docker build \
 	  --build-arg PHP_VERSION=$(PHP_VERSION) \
 	  --build-arg XDEBUG_VERSION=$(XDEBUG_VERSION) \
 	  -t schema-registry-client:$(PHP_VERSION) \
@@ -29,27 +32,24 @@ docker:
 	  .
 
 composer-install:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(COMPOSER) install --no-interaction --no-progress --no-scripts --prefer-stable
+	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(COMPOSER) install --no-interaction --no-progress --no-scripts
 
 composer-update:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(COMPOSER) update --no-interaction --no-progress --no-scripts --prefer-stable
+	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(COMPOSER) update --no-interaction --no-progress --no-scripts $(COMPOSER_STABILITY)
 
 phpstan:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHP_STAN) analyse
+	PHP_VERSION=$(PHP_VERSION) $(PHP) -d memory_limit=-1 $(XDEBUG_OPTIONS) $(PHP_STAN) analyse
 
 cs-fixer:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHP_CS_FIXER) fix --config=.php_cs.dist --diff -v --dry-run \
+	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHP_CS_FIXER) fix --config=.php-cs-fixer.dist.php --diff -v --dry-run \
 	  --path-mode=intersection --allow-risky=yes src test
 
 cs-fixer-modify:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHP_CS_FIXER) fix --config=.php_cs.dist --diff -v \
+	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHP_CS_FIXER) fix --config=.php-cs-fixer.dist.php --diff -v \
 	  --path-mode=intersection --allow-risky=yes src test
 
 phpunit:
 	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHPUNIT) --exclude-group integration
-
-phpunit-integration:
-	PHP_VERSION=$(PHP_VERSION) $(PHP) $(XDEBUG_OPTIONS) $(PHPUNIT) --group integration
 
 coverage:
 	mkdir -p build
@@ -62,7 +62,7 @@ examples:
 	PHP_VERSION=$(PHP_VERSION) $(PHP) examples/*
 
 install-phars:
-	curl https://cs.symfony.com/download/php-cs-fixer-v2.phar -o bin/php-cs-fixer.phar -LR -z bin/php-cs-fixer.phar
+	curl https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v$(PHP_CS_FIXER_VERSION)/php-cs-fixer.phar -o bin/php-cs-fixer.phar -LR -z bin/php-cs-fixer.phar
 	chmod a+x bin/php-cs-fixer.phar
 	curl https://getcomposer.org/download/$(COMPOSER_VERSION)/composer.phar -o bin/composer.phar -LR -z bin/composer.phar
 	chmod a+x bin/composer.phar
@@ -73,6 +73,9 @@ platform:
 	docker-compose down
 	docker-compose up -d
 	bin/wait-for-all.sh
+
+platform-logs:
+	docker-compose logs -f
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Total Downloads](https://poser.pugx.org/flix-tech/confluent-schema-registry-api/downloads)](https://packagist.org/packages/flix-tech/confluent-schema-registry-api)
 [![License](https://poser.pugx.org/flix-tech/confluent-schema-registry-api/license)](https://packagist.org/packages/flix-tech/confluent-schema-registry-api)
 
-A PHP 7.3+ library to consume the Confluent Schema Registry REST API. It provides low level functions to create PSR-7
+A PHP 7.4+ library to consume the Confluent Schema Registry REST API. It provides low level functions to create PSR-7
 compliant requests that can be used as well as high level abstractions to ease developer experience.
 
 #### Contents
@@ -33,8 +33,8 @@ compliant requests that can be used as well as high level abstractions to ease d
 
 | Dependency | Version | Reason |
 |:--- |:---:|:--- |
-| **`php`** | ~7.3 | Anything lower has reached EOL |
-| **`guzzlephp/guzzle`** | ~6.3 | Using `Request` to build PSR-7 `RequestInterface` |
+| **`php`** | ~7.4 | Anything lower has reached EOL |
+| **`guzzlephp/guzzle`** | ~7.0 | Using `Request` to build PSR-7 `RequestInterface` |
 | **`beberlei/assert`** | ~2.7\|~3.0 | The de-facto standard assertions library for PHP |
 | **`flix-tech/avro-php`** | ^4.1 | Maintained fork of the only Avro PHP implementation: `rg/avro-php` |
 

--- a/bin/php
+++ b/bin/php
@@ -16,6 +16,7 @@ exec docker run ${DOCKER_OPTS} --rm \
     -v "${COMPOSER_HOME}":/tmp/composer \
     -w ${PWD} \
     -e PHP_IDE_CONFIG="serverName=schema-registry-client" \
+    -e PHP_CS_FIXER_IGNORE_ENV=1 \
     -e COMPOSER_HOME="/tmp/composer" \
     --net=host --sig-proxy=true --pid=host \
     --entrypoint="php" \

--- a/bin/wait-for-all.sh
+++ b/bin/wait-for-all.sh
@@ -6,4 +6,4 @@ SCHEMA_REGISTRY_IPV4=${SCHEMA_REGISTRY_IPV4:-localhost}
 
 bin/wait-for-it.sh "${ZOOKEEPER_IPV4}:2181" -t 30 -- echo "zookeeper is up"
 bin/wait-for-it.sh "${KAFKA_BROKER_IPV4}:9092" -t 30 -- echo "kafka broker is up"
-bin/wait-for-it.sh "${SCHEMA_REGISTRY_IPV4}:8081" -t 30 -- echo "schema registry is up"
+bin/wait-for-it.sh "${SCHEMA_REGISTRY_IPV4}:8081" -t 60 -- echo "schema registry is up"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "flix-tech/confluent-schema-registry-api",
-  "description": "A PHP 7.3+ library to consume the Confluent Schema Registry REST API.",
+  "description": "A PHP 7.4+ library to consume the Confluent Schema Registry REST API.",
   "minimum-stability": "stable",
   "type": "library",
   "license": "MIT",
@@ -11,17 +11,17 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^7.4|^8.0|8.1.*",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~6.3|^7.0",
+    "guzzlehttp/guzzle": "^7.0",
     "guzzlehttp/promises": "^1.4.0",
     "guzzlehttp/psr7": "^1.7",
     "beberlei/assert": "~2.7|~3.0",
     "flix-tech/avro-php": "^4.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.2.3|^9.4.2",
+    "phpunit/phpunit": "^9.4.2",
     "raphhh/trex-reflection": "~1.0",
     "doctrine/cache": "~1.3",
     "psr/cache": "^1.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     networks:
-      avro-serializer-net:
+      schema-registry-net:
         ipv4_address: ${ZOOKEEPER_IPV4}
 
   broker:
@@ -24,8 +24,9 @@ services:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://172.68.0.102:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     networks:
-      avro-serializer-net:
+      schema-registry-net:
         ipv4_address: ${KAFKA_BROKER_IPV4}
 
   schema_registry:
@@ -39,13 +40,17 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: ${SCHEMA_REGISTRY_IPV4}
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_LISTENERS: "http://${SCHEMA_REGISTRY_IPV4}:8081"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://172.68.0.102:9092'
     networks:
-      avro-serializer-net:
+      schema-registry-net:
         ipv4_address: ${SCHEMA_REGISTRY_IPV4}
 
 networks:
-  avro-serializer-net:
+  schema-registry-net:
     driver: bridge
     ipam:
+      driver: default
       config:
-      - subnet: ${CONFLUENT_NETWORK_SUBNET}
+      - subnet: "${CONFLUENT_NETWORK_SUBNET}"
+        gateway: "${CONFLUENT_NETWORK_GATEWAY}"

--- a/phpunit.xml.integration.dist
+++ b/phpunit.xml.integration.dist
@@ -2,7 +2,7 @@
 
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
         bootstrap="test/bootstrap.php"
         colors="true"
 >


### PR DESCRIPTION
- Remove Guzzle 6.x
- Allow PHP 8.1
- Remove PHPUnit 8.x
- Upgrade PHP-CS-Fixer, PHPStan and composer versions
- Update xdebug version
- Update & optimize GH actions
- Update `README.md`
- Update docker-compose CP setup for newer versions 