### PR TITLE
Allow guzzlehttp/psr7 ^1.7|^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.0",
     "guzzlehttp/promises": "^1.4.0",
-    "guzzlehttp/psr7": "^1.7",
+    "guzzlehttp/psr7": "^1.7|^2.1",
     "beberlei/assert": "~2.7|~3.0",
     "flix-tech/avro-php": "^4.1"
   },


### PR DESCRIPTION
I got a conflict on `guzzlehttp/psr7` when installing this package. Other dependencies of the project I am working on have `^1.7|^2.1` as version constraint. So why not add it in this package.

I've ran the tests, all seems well!