### PR TITLE
Fixed error message for connection exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0|8.1.*",
+    "php": "^7.4|^8.0|^8.1",
     "ext-curl": "*",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.0",

--- a/src/Exception/ExceptionMap.php
+++ b/src/Exception/ExceptionMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FlixTech\SchemaRegistryApi\Exception;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
@@ -38,14 +39,18 @@ final class ExceptionMap
     /**
      * Maps a RequestException to the internal SchemaRegistryException types.
      *
-     * @param RequestException $exception
+     * @param GuzzleException $exception
      *
      * @return SchemaRegistryException
      *
      * @throws RuntimeException
      */
-    public function __invoke(RequestException $exception): SchemaRegistryException
+    public function __invoke(GuzzleException $exception): SchemaRegistryException
     {
+        if (!$exception instanceof RequestException) {
+            throw $exception;
+        }
+
         $response = $this->guardAgainstMissingResponse($exception);
         $decodedBody = $this->guardAgainstMissingErrorCode($response);
         $errorCode = $decodedBody[self::ERROR_CODE_FIELD_NAME];

--- a/src/Registry/PromisingRegistry.php
+++ b/src/Registry/PromisingRegistry.php
@@ -11,7 +11,6 @@ use FlixTech\SchemaRegistryApi\Exception\ExceptionMap;
 use FlixTech\SchemaRegistryApi\Schema\AvroReference;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;

--- a/src/Registry/PromisingRegistry.php
+++ b/src/Registry/PromisingRegistry.php
@@ -10,6 +10,7 @@ use FlixTech\SchemaRegistryApi\AsynchronousRegistry;
 use FlixTech\SchemaRegistryApi\Exception\ExceptionMap;
 use FlixTech\SchemaRegistryApi\Schema\AvroReference;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use InvalidArgumentException;
@@ -45,7 +46,7 @@ class PromisingRegistry implements AsynchronousRegistry
         $this->client = $client;
         $exceptionMap = ExceptionMap::instance();
 
-        $this->rejectedCallback = static function (RequestException $exception) use ($exceptionMap) {
+        $this->rejectedCallback = static function (GuzzleException $exception) use ($exceptionMap) {
             return $exceptionMap($exception);
         };
     }


### PR DESCRIPTION
Hi there!

There is only handling of Guzzle RequestExceptions. When my team and I got another type of exception - package drives us crazy with it's message 😅 I've changed this behavior, and turn this:

![image](https://user-images.githubusercontent.com/33313896/179897754-3303c9e3-0b08-4ae9-8a28-5e1e44a147d1.png)

into this:

![image](https://user-images.githubusercontent.com/33313896/179897770-331da45d-b1d0-4c9a-8e87-de2aa1dc2a3b.png)
