### PR TITLE
Fix jsonSerialize on PHP 8.1+

### DIFF
--- a/src/Schema/AvroReference.php
+++ b/src/Schema/AvroReference.php
@@ -37,7 +37,7 @@ final class AvroReference implements \JsonSerializable
         $this->version = $version;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'name' => (string) $this->name,

--- a/src/Schema/AvroReference.php
+++ b/src/Schema/AvroReference.php
@@ -13,7 +13,6 @@ final class AvroReference implements \JsonSerializable
      */
     private $name;
 
-
     /**
      * @var string
      */
@@ -37,7 +36,8 @@ final class AvroReference implements \JsonSerializable
         $this->version = $version;
     }
 
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             'name' => (string) $this->name,


### PR DESCRIPTION
```
During inheritance of JsonSerializable: Uncaught ErrorException: Return type of FlixTech\SchemaRegistryApi\Schema\AvroReference::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```