### PR TITLE
Update CachedRegistry.php

### DIFF
--- a/src/Registry/CachedRegistry.php
+++ b/src/Registry/CachedRegistry.php
@@ -32,7 +32,7 @@ class CachedRegistry implements Registry
      */
     private $hashAlgoFunc;
 
-    public function __construct(Registry $registry, CacheAdapter $cacheAdapter, callable $hashAlgoFunc = null)
+    public function __construct(Registry $registry, CacheAdapter $cacheAdapter, ?callable $hashAlgoFunc = null)
     {
         $this->registry = $registry;
         $this->cacheAdapter = $cacheAdapter;


### PR DESCRIPTION
Fix PHP deprecation error in PHP 8.4:
vendor/flix-tech/confluent-schema-registry-api/src/Registry/CachedRegistry.php:35 FlixTech\SchemaRegistryApi\Registry\CachedRegistry::__construct(): Implicitly marking parameter $hashAlgoFunc as nullable is deprecated, the explicit nullable type must be used instead